### PR TITLE
Removed shortcode as fallback senderId

### DIFF
--- a/lib/src/africas_talking_base.dart
+++ b/lib/src/africas_talking_base.dart
@@ -145,9 +145,9 @@ class Sms  {
     return await africasTalking.httpPostProcess(
       africasTalking.isLive ? smsLiveUrl : smsTestUrl,
       {
-        'from': (from ?? shortCode).toString(),
         'to': to.join(','),
         'message': message,
+        if(from != null) ...{'from': from},
         if(bulkSMSMode != null) ...{'bulkSMSMode': bulkSMSMode},
         if(enqueue != null) ...{'enqueue': enqueue},
         if(keyword != null) ...{'keyword': keyword},


### PR DESCRIPTION
When `from` is not set, calling `Sms.send()` returns an error : `{"SMSMessageData":{"Message":"InvalidSenderId","Recipients":[]}}`. This is because the shortCode is used as the fallback `senderId` which is not allowed.